### PR TITLE
feat: add optional checksum annotations for ConfigMaps and Secrets

### DIFF
--- a/kubernetes/common.py
+++ b/kubernetes/common.py
@@ -358,6 +358,11 @@ class VPAConfigSpec(kgenlib.BaseModel):
     update_mode: str = "Auto"
     resource_policy: Dict[str, List[Dict]] = {}
 
+class HPAConfigSpec(kgenlib.BaseModel):
+    min_replicas: Optional[int] = None
+    max_replicas: Optional[int] = None
+    metrics: List[Dict[str, Any]] = []
+
 
 class ServiceMonitororConfigSpec(kgenlib.BaseModel):
     endpoints: list = []
@@ -382,6 +387,8 @@ class WorkloadConfigSpec(KubernetesResourceSpec, ContainerSpec):
     application: Optional[str] = None
     auto_pdb: bool = False
     backend_config: dict = {}
+    checksum_annotation: bool = False
+    frontend_config: dict = {}
     cluster_role: Optional[Dict] = None
     containers: dict = {}
     deployment_progress_deadline_seconds: int | None = None
@@ -389,7 +396,7 @@ class WorkloadConfigSpec(KubernetesResourceSpec, ContainerSpec):
     grace_period: int = 30
     host_network: Optional[bool] = None
     host_pid: Optional[bool] = None
-    hpa: dict = {}
+    hpa: Optional[HPAConfigSpec] = None
     image_pull_secrets: list = []
     init_containers: Optional[Dict[str, Union[InitContainerSpec, None]]] = {}
     istio_policy: dict = {}


### PR DESCRIPTION
This adds support for computing and injecting SHA256 checksums of all ConfigMaps and Secrets used by a workload as pod template annotations (e.g., `checksum/foo`, `checksum/-bar`). This enables automatic rollouts of Deployments, StatefulSets, and DaemonSets when underlying config or secret data changes.
Defaults to false

Controlled via a new inventory parameter `checksum_annotation` Can be set per component or in resource_defaults per component type:
```yaml
  parameters:
    generators:
      manifest:
        resource_defaults:
          deployment:
            checksum_annotation: true
```

```yaml
  parameters:
    components
      my-component:
        checksum_annotation: true
```

Only applies to Deployment, StatefulSet, and DaemonSet workloads.