### PR TITLE
feat: add optional checksum annotations for ConfigMaps and Secrets

### DIFF
--- a/kubernetes/common.py
+++ b/kubernetes/common.py
@@ -386,6 +386,8 @@ class WorkloadConfigSpec(KubernetesResourceSpec, ContainerSpec):
     application: Optional[str] = None
     auto_pdb: bool = False
     backend_config: dict = {}
+    checksum_annotation: bool = False
+    frontend_config: dict = {}
     frontend_config: dict = {}
     cluster_role: Optional[Dict] = None
     containers: dict = {}


### PR DESCRIPTION
This adds support for computing and injecting SHA256 checksums of all ConfigMaps and Secrets used by a workload as pod template annotations (e.g., `checksum/foo`, `checksum/-bar`). This enables automatic rollouts of Deployments, StatefulSets, and DaemonSets when underlying config or secret data changes.
Defaults to false

Controlled via a new inventory parameter `checksum_annotation` Can be set per component or in resource_defaults per component type:
```yaml
  parameters:
    generators:
      manifest:
        resource_defaults:
          deployment:
            checksum_annotation: true
```

```yaml
  parameters:
    components
      my-component:
        checksum_annotation: true
```

Only applies to Deployment, StatefulSet, and DaemonSet workloads.

# Conflicts:
#	kubernetes/common.py
#	kubernetes/workloads.py